### PR TITLE
Fix: RepositoryModel.ActualizeRepositories call is missed

### DIFF
--- a/DXVisualTestFixer.Core/Config/Config.cs
+++ b/DXVisualTestFixer.Core/Config/Config.cs
@@ -19,7 +19,7 @@ namespace DXVisualTestFixer.Core.Configuration {
         public string WorkingDirectory { get; set; } = @"C:\Work";
 
         public IEnumerable<Repository> GetLocalRepositories() {
-            return Repositories.Where(r => r.IsDownloaded());
+            return Repositories != null ? Repositories.Where(r => r.IsDownloaded()) : new Repository[0];
         }
 
         public static Config GenerateDefault(IConfigSerializer configSerializer) {
@@ -36,17 +36,19 @@ namespace DXVisualTestFixer.Core.Configuration {
                 config.InstallPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             if(string.IsNullOrEmpty(config.WorkingDirectory))
                 config.WorkingDirectory = @"C:\Work";
-            var currentRepos = config.Repositories.Where(repo => Repository.Versions.Contains(repo.Version)).ToArray();
-            if(currentRepos.Length != config.Repositories.Length)
-                config.Repositories = currentRepos;
-            var reposToDownload = new List<Repository>();
-            foreach(var version in Repository.Versions) {
-                if(config.Repositories.Select(r => r.Version).Contains(version))
-                    continue;
-                reposToDownload.Add(new Repository() { Version = version, Path = System.IO.Path.Combine(config.WorkingDirectory, $"20{version}_VisualTests") });
+            if(config.Repositories != null) {
+                var currentRepos = config.Repositories.Where(repo => Repository.Versions.Contains(repo.Version)).ToArray();
+                if(currentRepos.Length != config.Repositories.Length)
+                    config.Repositories = currentRepos;
+                var reposToDownload = new List<Repository>();
+                foreach(var version in Repository.Versions) {
+                    if(config.Repositories.Select(r => r.Version).Contains(version))
+                        continue;
+                    reposToDownload.Add(new Repository() {Version = version, Path = System.IO.Path.Combine(config.WorkingDirectory, $"20{version}_VisualTests")});
+                }
+                if(reposToDownload.Count > 0)
+                    config.Repositories = Enumerable.Concat(config.Repositories, reposToDownload).ToArray();
             }
-            if(reposToDownload.Count > 0)
-                config.Repositories = Enumerable.Concat(config.Repositories, reposToDownload).ToArray();
             return config;
         }
     }

--- a/DXVisualTestFixer.UI/ViewModels/MainViewModel.cs
+++ b/DXVisualTestFixer.UI/ViewModels/MainViewModel.cs
@@ -268,11 +268,11 @@ namespace DXVisualTestFixer.UI.ViewModels {
         async Task<bool> ActualizeRepositories() {
             foreach(var repo in Config.GetLocalRepositories()) {
                 if(!_GitWorker.SetHttpRepository(repo)) {
-                    notificationService.DoNotification("Updating reposiroty source failed", $"Cann't update source (origin or upstream) for repository {repo.Version} that located at {repo.Path}", MessageBoxImage.Error);
+                    notificationService.DoNotification("Updating repository source failed", $"Can't update source (origin or upstream) for repository {repo.Version} that located at {repo.Path}", MessageBoxImage.Error);
                     return await Task.FromResult(false);
                 }
                 if(await _GitWorker.Update(repo) == GitUpdateResult.Error) {
-                    notificationService.DoNotification("Updating failed", $"Repository {repo.Version} in {repo.Path} cann't update", MessageBoxImage.Error);
+                    notificationService.DoNotification("Updating failed", $"Repository {repo.Version} in {repo.Path} can't update", MessageBoxImage.Error);
                     return await Task.FromResult(false);
                 }
             }
@@ -281,7 +281,7 @@ namespace DXVisualTestFixer.UI.ViewModels {
         async Task<bool> PushTestsInRepository() {
             foreach(var group in TestService.ActualState.ChangedTests.GroupBy(t => t.Repository)) {
                 if(await _GitWorker.Commit(group.Key) == GitCommitResult.Error) {
-                    notificationService.DoNotification("Pushing failed", $"Cann't push repository {group.Key.Version} that located at {group.Key.Path}", MessageBoxImage.Error);
+                    notificationService.DoNotification("Pushing failed", $"Can't push repository {group.Key.Version} that located at {group.Key.Path}", MessageBoxImage.Error);
                     return await Task.FromResult(false);
                 }
             }

--- a/DXVisualTestFixer.UI/ViewModels/SettingsViewModel.cs
+++ b/DXVisualTestFixer.UI/ViewModels/SettingsViewModel.cs
@@ -70,6 +70,7 @@ namespace DXVisualTestFixer.UI.ViewModels {
                 repo.Path = System.IO.Path.Combine(WorkingDirectory, $"20{repo.Version}_VisualTests");
                 repo.UpdateDownloadState();
             }
+            RepositoryModel.ActualizeRepositories(Repositories, WorkingDirectory);
         }
 
         void OnConfigChanged() {

--- a/DXVisualTestFixer.UI/Views/MainView.xaml
+++ b/DXVisualTestFixer.UI/Views/MainView.xaml
@@ -229,7 +229,7 @@
                                 </DataTemplate>
                             </dxb:BarSubItem.ItemTemplate>
                         </dxb:BarSubItem>
-                        <dxb:BarSubItem Content="Open Folder" Glyph="pack://application:,,,/DevExpress.Images.v17.2;component/DevAV/Actions/OpenDoc_16x16.png" RibbonStyle="SmallWithText"
+                        <dxb:BarSubItem Content="Open Folder" Glyph="pack://application:,,,/DevExpress.Images.v18.2;component/DevAV/Actions/OpenDoc_16x16.png" RibbonStyle="SmallWithText"
                                         ItemLinksSource="{Binding Solutions}">
                             <dxb:BarSubItem.ItemTemplate>
                                 <DataTemplate>


### PR DESCRIPTION
I believe that you've missed to call the RepositoryModel.ActualizeRepositories method after the working directory has been changed